### PR TITLE
refactor: use default export

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,127 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,78 @@
+[mysql]: https://github.com/mysqljs/mysql
+[mysql2]: https://github.com/mysqljs/mysql
+[docs-contributing]: https://sidorares.github.io/node-mysql2/docs/contributing/website
+
+# Contributing Guidelines
+
+## Introduction
+
+Contributions are always welcomed. You can help **AWS SSL Profiles** community in various ways.
+Here are our major priorities, listed in order of importance:
+
+- [**Node MySQL**][mysql] and [**MySQL2**][mysql2] API incompatibility fixes
+- Adding tests or improving existing ones
+- Bug Fixes
+- Performance improvements
+- Documentation
+
+---
+
+## Environment
+
+You will need these tools installed on your system:
+
+- [**Node.js**](https://nodejs.org)
+
+---
+
+## Development
+
+Fork this project, create a new branch from `main`, then run `npm ci` to clean install the node modules.
+
+---
+
+### Commits and Pull Request Titles
+
+To ensure a clean commit history pattern, please use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format.
+
+Prefixes that will trigger a new release version:
+
+- `fix:` for patches, e.g., bug fixes that result in a patch version release.
+- `feat:` for new features, e.g., additions that result in a minor version release.
+  - It's better to discuss an API before actually start implementing it. You can open an issue on Github. We can discuss design of API and implementation ideas.
+
+Examples:
+
+- `fix: message`
+- `fix(module): message`
+- `docs: message`
+- etc.
+
+---
+
+### Including Tests
+
+#### Fixes
+
+Where possible, provide an error test case that your fix covers.
+
+#### Features
+
+Please ensure test cases to cover your features.
+
+---
+
+### Running Tests
+
+```sh
+npm run test
+```
+
+You can also run all the tests that will be executed in the CI, such as _build_, _lint_, etc., by running:
+
+```sh
+npm run test:ci
+```
+
+> [!Tip]
+> You can also run a single test by performing `npx tsx test/path-to-test-file.test.ts` to debug easily.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2024 Andrey Sidorov, Douglas Wilson, Weslley Araújo and contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # AWS SSL Profiles
 
-AWS RDS Certificates Bundles
+[**AWS RDS**](https://aws.amazon.com/rds/) Certificates Bundles.
 
 ## Install
 
 ```bash
-npm install aws-ssl-profiles
+npm install --save aws-ssl-profiles
 ```
+
+---
 
 ## Usage
 
@@ -19,3 +21,27 @@ const connection = mysql.createConnection({
   ssl: awsCaBundle,
 });
 ```
+
+---
+
+## License
+
+**AWS SSL Profiles** is under the [**MIT License**](./LICENSE).
+
+---
+
+## Security
+
+Please check the [**SECURITY.md**](./SECURITY.md).
+
+---
+
+## Contributing
+
+Please check the [**CONTRIBUTING.md**](./CONTRIBUTING.md) for instructions.
+
+---
+
+## Acknowledgements
+
+[**Contributors**.](https://github.com/mysqljs/aws-ssl-profiles/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # AWS SSL Profiles
 
 AWS RDS Certificates Bundles
+
+## Install
+
+```bash
+npm install aws-ssl-profiles
+```
+
+## Usage
+
+```js
+const awsCaBundle = require('aws-ssl-profiles');
+
+// mysql or mysql2 connection
+const connection = mysql.createConnection({
+  //...
+  ssl: awsCaBundle,
+});
+```

--- a/SECURITY.MD
+++ b/SECURITY.MD
@@ -1,0 +1,5 @@
+Report security bugs by emailing the current owner(s) of **AWS SSL Profiles**.
+
+This information can be found in the npm registry using the command `npm owner ls aws-ssl-profiles`.
+
+If unsure or unable to get the information from the above, open an issue in the [project issue tracker](https://github.com/mysqljs/aws-ssl-profiles/issues) asking for the current contact information.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 import { Profiles } from './@types/profiles.js';
 import { defaults } from './profiles/ca/defaults.js';
 
-export const profiles: Profiles = {
+const profiles: Profiles = {
   ca: defaults,
 };
+
+// eslint-disable-next-line import/no-default-export
+export default profiles;

--- a/src/profiles/ca/defaults.ts
+++ b/src/profiles/ca/defaults.ts
@@ -1,3 +1,5 @@
+import { CA } from '../../@types/profiles.js';
+
 /**
  * CA Certificates for **Amazon RDS** (2024)
  *
@@ -5,9 +7,6 @@
  * - https://docs.amazonaws.cn/en_us/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.SSL.html
  * - https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless.html#aurora-serverless.tls
  */
-
-import { CA } from '../../@types/profiles.js';
-
 export const defaults: CA = [
   '-----BEGIN CERTIFICATE-----\n' +
     'MIIEEjCCAvqgAwIBAgIJAM2ZN/+nPi27MA0GCSqGSIb3DQEBCwUAMIGVMQswCQYD\n' +

--- a/test/integration/import.test.ts
+++ b/test/integration/import.test.ts
@@ -1,9 +1,0 @@
-import { describe, assert } from 'poku';
-import * as index from '../../src/index.js';
-
-describe('Testing Imports', {
-  pad: true,
-  background: false,
-});
-
-assert(index.profiles, 'Import default profiles');

--- a/test/unit/profiles.test.ts
+++ b/test/unit/profiles.test.ts
@@ -1,5 +1,5 @@
 import { describe, assert } from 'poku';
-import { profiles } from '../../src/index.js';
+import profiles from '../../src/index.js';
 
 describe('Testing Profiles Final Bundle Structure', {
   pad: true,


### PR DESCRIPTION
Changing default usage to:

```js
const awsCaBundle = require('aws-ssl-profiles');

// mysql or mysql2 connection
const connection = mysql.createConnection({
  //...
  ssl: awsCaBundle,
});
```

Also, creating all the common documents for the community sections.