### PR TITLE
docs: include `pg` and `pool` usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ const pool = mysql.createPool({
 const pg = require('pg');
 const awsCaBundle = require('aws-ssl-profiles');
 
-// node-postgres connection
+// pg connection
 const client = new pg.Client({
   // ...
   ssl: awsCaBundle,
 });
 
-// node-postgres connection pool
+// pg connection pool
 const pool = new pg.Pool({
   // ...
   ssl: awsCaBundle,

--- a/README.md
+++ b/README.md
@@ -1,8 +1,23 @@
 # AWS SSL Profiles
 
-[**AWS RDS**](https://aws.amazon.com/rds/) Certificates Bundles.
+[**AWS RDS**](https://aws.amazon.com/rds/) **SSL** Certificates Bundles.
 
-## Install
+**Table of Contents**
+
+- [Installation](#installation)
+- [Usage](#usage)
+  - [**mysqljs/mysql**](#mysqljsmysql)
+  - [**MySQL2**](#mysql2)
+  - [**node-postgres**](#node-postgres)
+  - [Custom `ssl` options](#custom-ssl-options)
+- [License](#license)
+- [Security](#security)
+- [Contributing](#contributing)
+- [Acknowledgements](#acknowledgements)
+
+---
+
+## Installation
 
 ```bash
 npm install --save aws-ssl-profiles

--- a/README.md
+++ b/README.md
@@ -12,18 +12,38 @@ npm install --save aws-ssl-profiles
 
 ## Usage
 
-### [node-mysql](https://github.com/mysqljs/mysql) and [node-mysql2](https://github.com/sidorares/node-mysql2)
+### [node-mysql](https://github.com/mysqljs/mysql)
 
 ```js
+const mysql = require('mysql');
 const awsCaBundle = require('aws-ssl-profiles');
 
-// mysql or mysql2 connection
+// mysql connection
 const connection = mysql.createConnection({
   //...
   ssl: awsCaBundle,
 });
 
-// mysql or mysql2 connection pool
+// mysql connection pool
+const pool = mysql.createPool({
+  //...
+  ssl: awsCaBundle,
+});
+```
+
+### [node-mysql2](https://github.com/sidorares/node-mysql2)
+
+```js
+const mysql = require('mysql2');
+const awsCaBundle = require('aws-ssl-profiles');
+
+// mysql2 connection
+const connection = mysql.createConnection({
+  //...
+  ssl: awsCaBundle,
+});
+
+// mysql2 connection pool
 const pool = mysql.createPool({
   //...
   ssl: awsCaBundle,
@@ -47,6 +67,32 @@ const pool = new pg.Pool({
   // ...
   ssl: awsCaBundle,
 });
+```
+
+### Custom `ssl` options
+
+Using **AWS SSL Profiles** with custom `ssl` options:
+
+```js
+{
+  // ...
+  ssl: {
+    ...awsCaBundle,
+    rejectUnauthorized: true,
+    // ...
+  }
+}
+```
+
+```js
+{
+  // ...
+  ssl: {
+    ca: awsCaBundle.ca,
+    rejectUnauthorized: true,
+    // ...
+  }
+}
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -12,12 +12,39 @@ npm install --save aws-ssl-profiles
 
 ## Usage
 
+### [node-mysql](https://github.com/mysqljs/mysql) and [node-mysql2](https://github.com/sidorares/node-mysql2)
+
 ```js
 const awsCaBundle = require('aws-ssl-profiles');
 
 // mysql or mysql2 connection
 const connection = mysql.createConnection({
   //...
+  ssl: awsCaBundle,
+});
+
+// mysql or mysql2 connection pool
+const pool = mysql.createPool({
+  //...
+  ssl: awsCaBundle,
+});
+```
+
+### [node-postgres](https://github.com/brianc/node-postgres)
+
+```js
+const pg = require('pg');
+const awsCaBundle = require('aws-ssl-profiles');
+
+// node-postgres connection
+const client = new pg.Client({
+  // ...
+  ssl: awsCaBundle,
+});
+
+// node-postgres connection pool
+const pool = new pg.Pool({
+  // ...
   ssl: awsCaBundle,
 });
 ```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ npm install --save aws-ssl-profiles
 
 ## Usage
 
-### [node-mysql](https://github.com/mysqljs/mysql)
+### [mysqljs/mysql](https://github.com/mysqljs/mysql)
 
 ```js
 const mysql = require('mysql');
@@ -31,7 +31,7 @@ const pool = mysql.createPool({
 });
 ```
 
-### [node-mysql2](https://github.com/sidorares/node-mysql2)
+### [MySQL2](https://github.com/sidorares/node-mysql2)
 
 ```js
 const mysql = require('mysql2');

--- a/package.json
+++ b/package.json
@@ -37,9 +37,13 @@
   "keywords": [
     "mysql",
     "mysql2",
+    "pg",
+    "postgres",
     "aws",
     "rds",
     "ssl",
+    "certificates",
+    "ca",
     "bundle"
   ],
   "scripts": {


### PR DESCRIPTION
Include a "Table of Contents" and some improvements to usage documentation, such as:

- Usage
  - mysqljs/mysql
  - MySQL2
  - node-postgres
  - Custom ssl options
