### PR TITLE
chore(npm): add `--provenance` to improve package transparency

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 jobs:
   release-please:
     runs-on: ubuntu-latest
@@ -53,4 +54,4 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish
+        run: npm publish --provenance


### PR DESCRIPTION
As suggested in https://github.com/sidorares/node-mysql2/issues/2996#issuecomment-2317743360.

A provenance example on **npm**:

<img width="480" alt="Screenshot 2024-08-29 at 10 53 19" src="https://github.com/user-attachments/assets/8181450f-be58-45df-a0be-58e523465dda">
